### PR TITLE
Switched to use JSON Canonicalization Scheme (JCS) for DID documents …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ derive_more = { version = "0.99.17", default-features = false, features = [
 selfhash = { version = "0.1", features = ["serde", "blake3"] }
 selfsign = { version = "0.2", features = ["serde"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde_json_canonicalizer = "0.2.0"
 serde_json = "1.0.106"
 serde_with = { version = "3.3.0", default-features = false, features = [
     "macros",

--- a/src/non_root_did_document.rs
+++ b/src/non_root_did_document.rs
@@ -145,12 +145,15 @@ impl NonRootDIDDocument {
 
 // NOTE: This could easily be derived because there is a clear and unique self-hash field.
 impl selfhash::SelfHashable for NonRootDIDDocument {
-    fn write_digest_data(&self, hasher: &mut dyn selfhash::Hasher) {
-        // NOTE: This is a generic JSON-serialization-based implementation.
+    fn write_digest_data(&self, mut hasher: &mut dyn selfhash::Hasher) {
+        // NOTE: This is a generic JSON Canonicalization Scheme (JCS) serialization based implementation.
         let mut c = self.clone();
         c.set_self_hash_slots_to(hasher.hash_function().placeholder_hash());
-        // Not sure if serde_json always produces the same output... TODO: Use JSONC or JCS probably
-        serde_json::to_writer(hasher, &c).unwrap();
+        // Use JCS to produce canonical output.  The `&mut hasher` ridiculousness is because
+        // serde_json_canonicalizer::to_writer uses a generic impl of std::io::Write and therefore
+        // implicitly requires the `Sized` trait.  Therefore passing in a reference to the reference
+        // achieves the desired effect.
+        serde_json_canonicalizer::to_writer(&c, &mut hasher).unwrap();
     }
     fn self_hash_oi<'a, 'b: 'a>(
         &'b self,
@@ -174,18 +177,21 @@ impl selfsign::SelfSignable for NonRootDIDDocument {
         &self,
         signature_algorithm: &dyn selfsign::SignatureAlgorithm,
         verifier: &dyn selfsign::Verifier,
-        hasher: &mut dyn selfhash::Hasher,
+        mut hasher: &mut dyn selfhash::Hasher,
     ) {
         assert!(verifier.key_type() == signature_algorithm.key_type());
         assert!(signature_algorithm
             .message_digest_hash_function()
             .equals(hasher.hash_function()));
-        // NOTE: This is a generic JSON-serialization-based implementation.
+        // NOTE: This is a generic JSON Canonicalization Scheme (JCS) serialization based implementation.
         let mut c = self.clone();
         c.set_self_signature_slots_to(&signature_algorithm.placeholder_keri_signature());
         c.set_self_signature_verifier_slots_to(verifier);
-        // Not sure if serde_json always produces the same output...
-        serde_json::to_writer(hasher, &c).expect("pass");
+        // Use JCS to produce canonical output.  The `&mut hasher` ridiculousness is because
+        // serde_json_canonicalizer::to_writer uses a generic impl of std::io::Write and therefore
+        // implicitly requires the `Sized` trait.  Therefore passing in a reference to the reference
+        // achieves the desired effect.
+        serde_json_canonicalizer::to_writer(&c, &mut hasher).unwrap();
     }
     fn self_signature_oi<'a, 'b: 'a>(
         &'b self,


### PR DESCRIPTION
…to produce the digest during self-sign and self-hash.